### PR TITLE
Add local testing database, initialize with data, and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ### Added
 - Docstrings for all classes and functions (#112) PR #124
 - Smaller screen layout (#58) PR #127
+- Documentation on running Jest tests w/ Docker. PR #130
+- Local testing database for `dev` Docker environment. PR #130
 
 ### Fixed
 - Make table column width fit content or header and make it resizable (#11) PR #127
@@ -14,6 +16,9 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Replaced usage of any with more strongly typed data types (#125) PR #124
 - Replaced the direct react component props definition with interface PR #124
 - Replaced state and props with interface instead of types PR #124
+
+### Removed
+- Duplicate `volume` config for `pharus` service in `dev` Docker environment. PR #130
 
 ## [0.1.0-beta.2] - 2021-03-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For now, development observes the following policy for branches:
 1) Copy a `*-docker-compose.yaml` file corresponding to your usage to `docker-compose.yaml`. This file is untracked so feel free to modify as necessary. Idea is to commit anything generic but system/setup dependent should go on 'your' version i.e. local UID/GID, etc.
 2) Check the first comment which will provide the best instruction on how to start the service; yes, it is a bit long. Note: Any of the keyword arguments prepended to the `docker-compose` command can be safely moved into a dedicated `.env` and read automatically if they are not evaluated i.e. `$(...)`. Below is a brief description of the non-evaluated environment variables:
 
-  ```shell
-  PY_VER=3.8    # (pharus) Python version: 3.6|3.7|3.8
-  IMAGE=djtest  # (pharus) Image type:     djbase|djtest|djlab|djlabhub
-  DISTRO=alpine # (pharus) Distribution:   alpine|debian
-  ```
+   ```shell
+   PY_VER=3.8    # (pharus) Python version: 3.6|3.7|3.8
+   IMAGE=djtest  # (pharus) Image type:     djbase|djtest|djlab|djlabhub
+   DISTRO=alpine # (pharus) Distribution:   alpine|debian
+   ```
 
 ## Run Tests w/ Docker
 
@@ -41,13 +41,13 @@ To run the test watcher, perform the following:
 
 1) In one terminal, start the `dev` Docker environment with the above instructions to start LabBook and Pharus with hot-reload support.
 2) In another terminal, you can run the watcher using:
-  ```shell
-  docker exec -it datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
-  ```
-  or run it once using:
-  ```shell
-  docker exec -ite CI=true datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
-  ```
+   ```shell
+   docker exec -it datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
+   ```
+   or run it once using:
+   ```shell
+   docker exec -ite CI=true datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
+   ```
 
 ## Working with git submodule dependency
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ For now, development observes the following policy for branches:
   DISTRO=alpine # (pharus) Distribution:   alpine|debian
   ```
 
+## Run Tests w/ Docker
+
+To run the test watcher, perform the following:
+
+1) In one terminal, start the `dev` Docker environment with the above instructions to start LabBook and Pharus with hot-reload support.
+2) In another terminal, you can run the watcher using:
+  ```shell
+  docker exec -it datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
+  ```
+  or run it once using:
+  ```shell
+  docker exec -ite CI=true datajoint-labbook_datajoint-labbook_1 npm test -- --coverage
+  ```
+
 ## Working with git submodule dependency
 
 `pharus` is treated as a backend dependency managed by git's builtin submodules. It allows us to nest entire git repos with separate history and easy access. Below are some helpful commands to be used after cloning the source repo.

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -8,11 +8,21 @@
 # it is running properly by navigating in your browser to `https://fakeservices.datajoint.io`.
 # If you don't update your hosts file, you will still have access at `https://localhost`
 # however it should simply display 'Not secure' since the cert will be invalid.
+# Additionally, there is now a local-only database + account for development and testing. To
+# access it, connect using: database:local-db, user:root, password:labbook. Feel free to
+# alter any part of it as it will be reset between docker-compose down/up commands.
 version: "2.4"
 x-net: &net
   networks:
       - main
 services:
+  local-db:
+    <<: *net
+    image: datajoint/mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=labbook
+    volumes:
+      - ./tests/init/init.sql:/docker-entrypoint-initdb.d/init.sql
   pharus:
     <<: *net
     extends:
@@ -20,8 +30,9 @@ services:
       service: pharus
     environment:
       - PHARUS_PORT=5000
-    volumes:
-      - ./pharus/pharus:/opt/conda/lib/python3.8/site-packages/pharus
+    depends_on:
+      local-db:
+        condition: service_healthy
   datajoint-labbook:
     <<: *net
     extends:

--- a/tests/init/init.sql
+++ b/tests/init/init.sql
@@ -1,0 +1,34 @@
+CREATE DATABASE `alpha_company`;
+CREATE DATABASE `empty`;
+
+CREATE TABLE `alpha_company`.`computer` (
+  `computer_id` binary(16) NOT NULL COMMENT ':uuid:unique id',
+  `computer_serial` varchar(9) NOT NULL COMMENT 'manufacturer serial number',
+  `computer_brand` enum('HP','Dell') NOT NULL COMMENT 'manufacturer brand',
+  `computer_built` date NOT NULL COMMENT 'manufactured date',
+  `computer_processor` double NOT NULL COMMENT 'processing power in GHz',
+  `computer_memory` int NOT NULL COMMENT 'RAM in GB',
+  `computer_weight` float NOT NULL COMMENT 'weight in lbs',
+  `computer_cost` decimal(6,2) NOT NULL COMMENT 'purchased price',
+  `computer_preowned` tinyint(1) NOT NULL COMMENT 'purchased as new or used',
+  `computer_purchased` datetime NOT NULL COMMENT 'purchased date and time',
+  `computer_updates` time DEFAULT NULL COMMENT 'scheduled daily update timeslot',
+  PRIMARY KEY (`computer_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Computers that belong to the company';
+
+INSERT INTO `alpha_company`.`computer` (computer_id, computer_serial, computer_brand, computer_built, computer_processor, computer_memory, computer_weight, computer_cost, computer_preowned, computer_purchased, computer_updates)
+VALUES
+(X'4e41491a86d54af7a01389bde75528bd', 'DJS1JA17G', 'Dell', '2020-05-25', 2.2, 16, 4.4, 700.99, 0, '2020-10-20 08:04:21', NULL)
+,(X'dcd4cfd96791433ca805f391c289e6ea', 'HUA20K9LL', 'HP', '2020-07-12', 2.8, 32, 5.7, 693.54, 1, '2020-11-05 13:58:02', '23:30:05');
+
+CREATE TABLE `alpha_company`.`#employee` (
+  `computer_id` binary(16) NOT NULL COMMENT ':uuid:unique id',
+  `employee_name` varchar(30) NOT NULL COMMENT 'employee name',
+  PRIMARY KEY (`computer_id`),
+  CONSTRAINT `#employee_ibfk_1` FOREIGN KEY (`computer_id`) REFERENCES `alpha_company`.`computer` (`computer_id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Employees that are assigned a computer';
+
+INSERT INTO `alpha_company`.`#employee` (computer_id, employee_name)
+VALUES
+(X'4e41491a86d54af7a01389bde75528bd', 'Raphael Guzman')
+,(X'dcd4cfd96791433ca805f391c289e6ea', 'John Doe');


### PR DESCRIPTION
Related to datajoint/datajoint-labbook#130

This PR:
- Adds a local-only testing database pre-populated with test data. Populating test data outside the context of the tests is atypical b/c it violates the principles for self-contained tests but we do not yet have support in `pharus` to create all that is necessary. This will serve for now and we can revisit once we expose more features in `pharus` to support it. Have a look in the header comment in the `docker-compose-dev.yaml` environment for more details on how to connect.
- Updates the `README.md` with details regarding running the tests once or in watch mode. Also, found the `--coverage` flag which will be helpful in tests necessary for uncovered components so it is included as well.
- Removes a duplicate `volume` config on `pharus` service.
- Updates the changelog.

Regarding GH Actions inclusion, we can wait until we have a bit more tests before pulling it in. Specially curious to see a test past the login page.